### PR TITLE
feat: extract RSSI and SNR data from packet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod steady;
 pub use steady::packets::fluctus_packet::FlightStatus;
 pub use steady::packets::fluctus_packet::FluctusPacket;
 pub use steady::packets::fluctus_packet::RollingMessage;
+pub use steady::packets::fluctus_packet::FluctusPacketMeta;
 
 pub use steady::commands::command::Command;
 pub use steady::commands::start::StartCommand;
@@ -19,7 +20,12 @@ mod tests {
 
     #[test]
     fn test_provided_packet() {
-        let packet: &'static str = "FB3E00070100BEDD01000000000000006C00AA89109CFF00650000000000000000000E53000000|Grssi-65/Gsnr6";
+        let packet = "FB3E00070100BEDD01000000000000006C00AA89109CFF00650000000000000000000E53000000|Grssi-65/Gsnr6";
+        let meta = FluctusPacketMeta::from_str(packet).unwrap();
+
+        assert!(meta.rssi == -65);
+        assert!(meta.snr == 6);
+
         let parsed_packet = FluctusPacket::from_str(packet);
         assert!(
             parsed_packet.is_ok(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_provided_packet() {
-        let packet = "FB3E00070100BEDD01000000000000006C00AA89109CFF00650000000000000000000E53000000|Grssi-65/Gsnr6";
+        let packet = "FB3E00070100BEDD01000000000000006C00AA89109CFF00650000000000000000000E53000000|Grssi-65/Gsnr6\n";
         let meta = FluctusPacketMeta::from_str(packet).unwrap();
 
         assert!(meta.rssi == -65);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod steady;
 pub use steady::packets::fluctus_packet::FlightStatus;
 pub use steady::packets::fluctus_packet::FluctusPacket;
-pub use steady::packets::fluctus_packet::RollingMessage;
 pub use steady::packets::fluctus_packet::FluctusPacketMeta;
+pub use steady::packets::fluctus_packet::RollingMessage;
 
 pub use steady::commands::command::Command;
 pub use steady::commands::start::StartCommand;

--- a/src/steady/packets/fluctus_packet.rs
+++ b/src/steady/packets/fluctus_packet.rs
@@ -50,12 +50,51 @@ pub struct FluctusPacket {
     pub user_in2: Option<i16>,
 }
 
-fn strip_code(code: &str) -> Result<String, String> {
+pub struct FluctusPacketMeta {
+    pub rssi: i16,
+    pub snr: i16,
+}
+
+impl FromStr for FluctusPacketMeta {
+    type Err = Box<dyn std::error::Error>;
+    fn from_str(code: &str) -> Result<Self, Self::Err> {
+        let meta = extract_meta(code)?;
+        Ok(meta)
+    }
+}
+
+fn extract_meta(code: &str) -> Result<FluctusPacketMeta, String> {
+    let meta_section = match code.split('|').nth(1) {
+        Some(s) => s,
+        None => return Err("missing meta section (expected text like Grssi‑65/Gsnr6)".into()),
+    };  
+    let meta_parts: Vec<&str> = meta_section.split('/').collect();
+
+    let rssi_str = meta_parts.get(0).copied().unwrap_or("Grssi0");
+    let snr_str = meta_parts.get(1).copied().unwrap_or("Gsnr1");
+
+    // Strip prefixes and parse values
+    let rssi = rssi_str.strip_prefix("Grssi")
+        .ok_or_else(|| format!("Invalid rssi format: '{}'", rssi_str))?
+        .parse::<i16>()
+        .map_err(|e| format!("Failed to parse rssi '{}': {}", rssi_str, e))?;
+
+    let snr = snr_str.strip_prefix("Gsnr")
+        .ok_or_else(|| format!("Invalid snr format: '{}'", snr_str))?
+        .parse::<i16>()
+        .map_err(|e| format!("Failed to parse snr '{}': {}", snr_str, e))?;
+
+    Ok(FluctusPacketMeta { rssi, snr })
+}
+
+
+fn extract_hexbytes(code: &str) -> Result<String, String> {
     // Trim any newline
     let code = code.trim();
     // Split the code by '/' and take the first part
     let parts: Vec<&str> = code.split('|').collect();
     let code = parts[0].trim();
+
     let first_char = code.chars().nth(0);
     // Check if the first character is 'F'
     if first_char != Some('F') {
@@ -94,7 +133,8 @@ impl FromStr for FluctusPacket {
     type Err = Box<dyn std::error::Error>;
 
     fn from_str(code: &str) -> Result<Self, Self::Err> {
-        let hex_str = strip_code(code)?;
+        let meta = extract_meta(code)?;
+        let hex_str = extract_hexbytes(code)?;
         let bytes = convert_to_bytes(&hex_str);
         FluctusPacket::from_bytes(&bytes)
     }

--- a/src/steady/packets/fluctus_packet.rs
+++ b/src/steady/packets/fluctus_packet.rs
@@ -49,7 +49,7 @@ pub struct FluctusPacket {
     pub user_in1: Option<i16>,
     pub user_in2: Option<i16>,
 }
-
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
 pub struct FluctusPacketMeta {
     pub rssi: i16,
     pub snr: i16,
@@ -64,6 +64,7 @@ impl FromStr for FluctusPacketMeta {
 }
 
 fn extract_meta(code: &str) -> Result<FluctusPacketMeta, String> {
+    let code = code.trim();
     let meta_section = match code.split('|').nth(1) {
         Some(s) => s,
         None => return Err("missing meta section (expected text like Grssi‑65/Gsnr6)".into()),

--- a/src/steady/packets/fluctus_packet.rs
+++ b/src/steady/packets/fluctus_packet.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use serde::Serialize;
+use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
 pub enum RollingMessage {
@@ -68,26 +68,27 @@ fn extract_meta(code: &str) -> Result<FluctusPacketMeta, String> {
     let meta_section = match code.split('|').nth(1) {
         Some(s) => s,
         None => return Err("missing meta section (expected text like Grssi‑65/Gsnr6)".into()),
-    };  
+    };
     let meta_parts: Vec<&str> = meta_section.split('/').collect();
 
     let rssi_str = meta_parts.get(0).copied().unwrap_or("Grssi0");
     let snr_str = meta_parts.get(1).copied().unwrap_or("Gsnr1");
 
     // Strip prefixes and parse values
-    let rssi = rssi_str.strip_prefix("Grssi")
+    let rssi = rssi_str
+        .strip_prefix("Grssi")
         .ok_or_else(|| format!("Invalid rssi format: '{}'", rssi_str))?
         .parse::<i16>()
         .map_err(|e| format!("Failed to parse rssi '{}': {}", rssi_str, e))?;
 
-    let snr = snr_str.strip_prefix("Gsnr")
+    let snr = snr_str
+        .strip_prefix("Gsnr")
         .ok_or_else(|| format!("Invalid snr format: '{}'", snr_str))?
         .parse::<i16>()
         .map_err(|e| format!("Failed to parse snr '{}': {}", snr_str, e))?;
 
     Ok(FluctusPacketMeta { rssi, snr })
 }
-
 
 fn extract_hexbytes(code: &str) -> Result<String, String> {
     // Trim any newline


### PR DESCRIPTION
This pulls the additional RSSI and SNR data that is sent as a kind of metadata from the steady ground station.